### PR TITLE
Add "--skip-innodb-read-only-compressed" flag to mariadb start command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
         image: mariadb
         restart: always
         # https://docs.nextcloud.com/server/stable/admin_manual/configuration_database/mysql_4byte_support.html
-        command: --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci --innodb-large-prefix --innodb-file-per-table --innodb-file-format=barracuda
+        command: --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci --innodb-large-prefix --innodb-file-per-table --innodb-file-format=barracuda --skip-innodb-read-only-compressed
         volumes:
             - mariadb:/var/lib/mysql
         environment:


### PR DESCRIPTION
In order to fix the error "4047 InnoDB refuses to write tables with ROW_FORMAT=COMPRESSED or KEY_BLOCK_SIZE." that appears on installation, i've taken the proposed solution from https://techoverflow.net/2021/08/17/how-to-fix-nextcloud-4047-innodb-refuses-to-write-tables-with-row_formatcompressed-or-key_block_size and now the installation works.
