### PR TITLE
update debian version

### DIFF
--- a/docker-mysql-proxy/Dockerfile
+++ b/docker-mysql-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:bullseye
 # docker build -t bscheshir/mysql-proxy:0.8.5 .
 MAINTAINER BSCheshir <bscheshir.work@gmail.com>
 


### PR DESCRIPTION
debian:jessie is outdated, build fails with:

`W: GPG error: http://deb.debian.org jessie-updates InRelease: The following signatures were invalid: KEYEXPIRED 1668891673`

Update to latest debian solves this.

Signed-off-by: Matthias <nextcloud@matthiasheinisch.de>